### PR TITLE
User.password null on login gives 500 response

### DIFF
--- a/src/authentication.ts
+++ b/src/authentication.ts
@@ -841,7 +841,7 @@ export function addAuthenticationAuthority(sapi: SakuraApi, options: IAuthentica
 
         debug('userInfo: ', userInfo);
 
-        if (!userInfo) {
+        if (!userInfo || !userInfo.password) {
           locals.send(401, {error: 'login_failed'});
           throw 401;
         }


### PR DESCRIPTION
Currently `bcrypt.compare` throws an error because the hash argument is required. It's passed in as null/undefined. This results in a 500 when it's not really the server's fault.

Some kind of action is needed on the user's part - a 4xx response. I'm not sure if this is exactly the right solution / error response. Maybe it should throw `password_reset_required` but I don't see this error message anywhere else in this file so I'm not sure if this plugin has that concept.